### PR TITLE
Linked to atom.io from linux instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download the latest [Particle Dev release](https://github.com/spark/particle-dev
 
 ### Linux
 
-Install Atom through your package manager and run `apm install particle-dev-complete`
+Install [Atom](https://atom.io/) through your package manager and run `apm install particle-dev-complete`
 
 ## Using
 


### PR DESCRIPTION
Added a link from the Linux installation instructions to the atom web page to solve a "where should I go now?" roadblock.